### PR TITLE
Fix compilation on KOS 2.2.X stable branch

### DIFF
--- a/quake/common/net.h
+++ b/quake/common/net.h
@@ -238,7 +238,9 @@ typedef struct
 extern int hostCacheCount;
 extern hostcache_t hostcache[HOSTCACHESIZE];
 
-#if !defined(_WIN32 ) && !defined (__linux__) && !defined (__sun__)
+#ifdef _arch_dreamcast
+#include <arpa/inet.h>
+#elif !defined(_WIN32 ) && !defined (__linux__) && !defined (__sun__)
 #ifndef htonl
 extern unsigned long htonl (unsigned long hostlong);
 #endif

--- a/quake/renderer/glquake.h
+++ b/quake/renderer/glquake.h
@@ -27,6 +27,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 #ifdef _arch_dreamcast
 
+#include <malloc.h>
+#include <dc/pvr.h>
+
 #ifndef BUILD_LIBGL
 #include <GL/gl.h>
 //#include <GL/glu.h> //@Note: unneeded anymore
@@ -38,9 +41,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "glext.h"
 #endif
 
-extern uint32_t pvr_mem_available(void);
-extern void malloc_stats(void);
-extern void pvr_mem_stats(void);
 #else
 #include <GL/gl.h>
 #include <GL/glext.h>

--- a/quake/renderer/menu_loader.c
+++ b/quake/renderer/menu_loader.c
@@ -16,6 +16,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #ifdef _arch_dreamcast
+#include <malloc.h>
+#include <dc/pvr.h>
 #include <sys/dirent.h>
 #else
 #include <dirent.h>
@@ -29,9 +31,6 @@ void DrawQuad(float x, float y, float w, float h, float u, float v, float uw, fl
 void BitmapLoad(char *path, GLuint *temp_tex);
 void glScaleF(float x, float y, float z);
 void GL_Set2D(void);
-
-extern uint32_t pvr_mem_available(void);
-extern void malloc_stats(void);
 
 extern unsigned int char_texture;
 


### PR DESCRIPTION
A few things changed in KOS, and because nuQuake hardcoded function signatures instead of pulling from KOS headers, this broke compilation. After this PR, nuQuake builds on KOS 2.2.X stable branch.